### PR TITLE
Save space on Docker by using ruby:2-slim

### DIFF
--- a/genghis/x86_64/Dockerfile
+++ b/genghis/x86_64/Dockerfile
@@ -1,8 +1,18 @@
-FROM ruby:2
+FROM ruby:2-slim
 
-RUN gem install --no-ri --no-rdoc \
+RUN buildDeps=' \
+		autoconf \
+    bison \
+    gcc \
+    make \
+  ' \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends $buildDeps \
+  && rm -rf /var/lib/apt/lists/* \
+  && gem install --no-ri --no-rdoc \
       bson_ext:1.9.2 \
-      genghisapp:2.3.11
+      genghisapp:2.3.11 \
+  && apt-get purge --yes --auto-remove $buildDeps
 
 EXPOSE 5000
 


### PR DESCRIPTION
Built image size on master: 728.9 MB 
Built image size on my PR: 291.2 MB

With this, you're saving **437,7 MB** of space.
